### PR TITLE
Add `enabled` var/option

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,13 @@ Available targets:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| admin_iam_role_arn | IAM Role with admin permissions to map to `admin_k8s_username` | string | - | yes |
+| admin_iam_role_arn | IAM Role with admin permissions to map to `admin_k8s_username` | string | `` | no |
 | admin_k8s_groups | List of Kubernetes groups to be mapped to `admin_iam_role_arn` | list | `<list>` | no |
 | admin_k8s_username | Kubernetes admin username to be mapped to `admin_iam_role_arn` | string | `` | no |
-| cluster_id | A unique-per-cluster identifier to prevent replay attacks. Good choices are a random token or a domain name that will be unique to your cluster | string | - | yes |
-| kube_config_path | Path to the kube config file. Can be sourced from `KUBE_CONFIG` or `KUBECONFIG` | string | - | yes |
-| readonly_iam_role_arn | IAM Role with readonly permissions to map to `readonly_k8s_username` | string | - | yes |
+| cluster_id | A unique-per-cluster identifier to prevent replay attacks. Good choices are a random token or a domain name that will be unique to your cluster | string | `random` | no |
+| enabled | Set to true to enable the module, otherwise it will not create any resources | string | `false` | no |
+| kube_config_path | Path to the kube config file. Can be sourced from `KUBE_CONFIG` or `KUBECONFIG` | string | `` | no |
+| readonly_iam_role_arn | IAM Role with readonly permissions to map to `readonly_k8s_username` | string | `` | no |
 | readonly_k8s_groups | List of Kubernetes groups to be mapped to `readonly_iam_role_arn` | list | `<list>` | no |
 | readonly_k8s_username | Kubernetes readonly username to be mapped to `readonly_iam_role_arn` | string | `` | no |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -2,12 +2,13 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| admin_iam_role_arn | IAM Role with admin permissions to map to `admin_k8s_username` | string | - | yes |
+| admin_iam_role_arn | IAM Role with admin permissions to map to `admin_k8s_username` | string | `` | no |
 | admin_k8s_groups | List of Kubernetes groups to be mapped to `admin_iam_role_arn` | list | `<list>` | no |
 | admin_k8s_username | Kubernetes admin username to be mapped to `admin_iam_role_arn` | string | `` | no |
-| cluster_id | A unique-per-cluster identifier to prevent replay attacks. Good choices are a random token or a domain name that will be unique to your cluster | string | - | yes |
-| kube_config_path | Path to the kube config file. Can be sourced from `KUBE_CONFIG` or `KUBECONFIG` | string | - | yes |
-| readonly_iam_role_arn | IAM Role with readonly permissions to map to `readonly_k8s_username` | string | - | yes |
+| cluster_id | A unique-per-cluster identifier to prevent replay attacks. Good choices are a random token or a domain name that will be unique to your cluster | string | `random` | no |
+| enabled | Set to true to enable the module, otherwise it will not create any resources | string | `false` | no |
+| kube_config_path | Path to the kube config file. Can be sourced from `KUBE_CONFIG` or `KUBECONFIG` | string | `` | no |
+| readonly_iam_role_arn | IAM Role with readonly permissions to map to `readonly_k8s_username` | string | `` | no |
 | readonly_k8s_groups | List of Kubernetes groups to be mapped to `readonly_iam_role_arn` | list | `<list>` | no |
 | readonly_k8s_username | Kubernetes readonly username to be mapped to `readonly_iam_role_arn` | string | `` | no |
 

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,7 @@
 resource "random_pet" "cluster" {
-  count       = "${var.enabled == "true" ? 1 : 0}"
+  count  = "${var.enabled == "true" ? 1 : 0}"
   length = 4
+
   keepers = {
     admin_iam_role_arn    = "${var.admin_iam_role_arn}"
     readonly_iam_role_arn = "${var.readonly_iam_role_arn}"
@@ -31,7 +32,8 @@ provider "kubernetes" {
 # https://github.com/kubernetes/kops/blob/master/docs/authentication.md
 # https://github.com/kubernetes-sigs/aws-iam-authenticator
 resource "kubernetes_config_map" "aws_iam_authenticator" {
-  count       = "${var.enabled == "true" ? 1 : 0}"
+  count = "${var.enabled == "true" ? 1 : 0}"
+
   metadata {
     name      = "aws-iam-authenticator"
     namespace = "kube-system"

--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,17 @@
+resource "random_pet" "cluster" {
+  count       = "${var.enabled == "true" ? 1 : 0}"
+  length = 4
+  keepers = {
+    admin_iam_role_arn    = "${var.admin_iam_role_arn}"
+    readonly_iam_role_arn = "${var.readonly_iam_role_arn}"
+  }
+}
+
 data "template_file" "config" {
   template = "${file("${path.module}/config.tpl")}"
 
   vars {
-    cluster_id            = "${var.cluster_id}"
+    cluster_id            = "${var.cluster_id == "random" ? element(concat(random_pet.cluster.*.id, list("")), 0) : var.cluster_id}"
     admin_iam_role_arn    = "${var.admin_iam_role_arn}"
     admin_k8s_username    = "${var.admin_k8s_username}"
     admin_k8s_groups      = "${jsonencode(var.admin_k8s_groups)}"
@@ -16,12 +25,13 @@ data "template_file" "config" {
 # https://www.terraform.io/docs/providers/kubernetes/index.html
 provider "kubernetes" {
   config_path      = "${var.kube_config_path}"
-  load_config_file = true
+  load_config_file = "${var.enabled == "true"}"
 }
 
 # https://github.com/kubernetes/kops/blob/master/docs/authentication.md
 # https://github.com/kubernetes-sigs/aws-iam-authenticator
 resource "kubernetes_config_map" "aws_iam_authenticator" {
+  count       = "${var.enabled == "true" ? 1 : 0}"
   metadata {
     name      = "aws-iam-authenticator"
     namespace = "kube-system"

--- a/variables.tf
+++ b/variables.tf
@@ -1,16 +1,25 @@
+variable "enabled" {
+  type        = "string"
+  description = "Set to true to enable the module, otherwise it will not create any resources"
+  default     = "false"
+}
+
 variable "cluster_id" {
   type        = "string"
   description = "A unique-per-cluster identifier to prevent replay attacks. Good choices are a random token or a domain name that will be unique to your cluster"
+  default = "random"
 }
 
 variable "kube_config_path" {
   type        = "string"
   description = "Path to the kube config file. Can be sourced from `KUBE_CONFIG` or `KUBECONFIG`"
+  default = ""
 }
 
 variable "admin_iam_role_arn" {
   type        = "string"
   description = "IAM Role with admin permissions to map to `admin_k8s_username`"
+  default = ""
 }
 
 variable "admin_k8s_username" {
@@ -28,6 +37,7 @@ variable "admin_k8s_groups" {
 variable "readonly_iam_role_arn" {
   type        = "string"
   description = "IAM Role with readonly permissions to map to `readonly_k8s_username`"
+  default = ""
 }
 
 variable "readonly_k8s_username" {

--- a/variables.tf
+++ b/variables.tf
@@ -7,19 +7,19 @@ variable "enabled" {
 variable "cluster_id" {
   type        = "string"
   description = "A unique-per-cluster identifier to prevent replay attacks. Good choices are a random token or a domain name that will be unique to your cluster"
-  default = "random"
+  default     = "random"
 }
 
 variable "kube_config_path" {
   type        = "string"
   description = "Path to the kube config file. Can be sourced from `KUBE_CONFIG` or `KUBECONFIG`"
-  default = ""
+  default     = ""
 }
 
 variable "admin_iam_role_arn" {
   type        = "string"
   description = "IAM Role with admin permissions to map to `admin_k8s_username`"
-  default = ""
+  default     = ""
 }
 
 variable "admin_k8s_username" {
@@ -37,7 +37,7 @@ variable "admin_k8s_groups" {
 variable "readonly_iam_role_arn" {
   type        = "string"
   description = "IAM Role with readonly permissions to map to `readonly_k8s_username`"
-  default = ""
+  default     = ""
 }
 
 variable "readonly_k8s_username" {


### PR DESCRIPTION
## what
- Add `enabled` var, default to `false` to keep this module disabled by default
- Generate a random `cluster_id` if none is provided. In this case, `cluster_id` refers to the `kops` RBAC IAM cluster ID, which is just a random unique string used to guard against replay attacks. It is not related to the general kops/kubernetes cluster name.

## why
Some users make this module part of a bundle, and would like to include the file without necessarily enabling this feature. Now they can include the file but leave the feature out.